### PR TITLE
Build 2.0.1 version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dependencies" %}
-{% set version = "7.7.0" %}
+{% set version = "2.0.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ae662ffe5726582705d26ae86977d0d616922100c38a211f0c27c765554fb026
+  sha256: 89f8262059ee6fb7a27f12bc72cec41e4a954a7b6f5ba0b4c902be1495e1cd12
 
 build:
   noarch: python


### PR DESCRIPTION
@conda-forge/dependencies, there's a package that I want to get into conda-forge that depends on this specific version and later versions do not work properly. Is it possible to merge this into a branch?